### PR TITLE
Remove Property#report

### DIFF
--- a/lib/rantly/property.rb
+++ b/lib/rantly/property.rb
@@ -81,12 +81,4 @@ class Rantly::Property
     end
     return min_data, max_depth, iteration
   end
-
-  def report
-    distribs = self.classifiers.sort { |a,b| b[1] <=> a[1] }
-    total = distribs.inject(0) { |sum,pair| sum + pair[1]}
-    distribs.each do |(classifier,count)|
-      format "%10.5f%% of => %s", count, classifier
-    end
-  end
 end


### PR DESCRIPTION
`Property#report` is not used and I think it has been never used. It was introduced 8 years ago in:

https://github.com/rantly-rb/rantly/commit/43ed5f55370b4b3739b7fd1eb2b54e0f8d8929b1

but `Property` has not even a `classifiers` variable. 🤔 