### PR TITLE
Add retry? method to Hash to be used in shrinkify

### DIFF
--- a/lib/rantly/shrinks.rb
+++ b/lib/rantly/shrinks.rb
@@ -191,4 +191,8 @@ class Hash
     self.any?{|_,v| v.respond_to?(:shrinkable?) && v.shrinkable? } ||
       !self.empty?
   end
+
+  def retry?
+    false
+  end
 end


### PR DESCRIPTION
`Rantly::Property#shrinkify` calls `retry?` which is defined for all classes in `shrinks.rb` except `Hash`. Consecuently it raises an `NoMethodError` when being called over a Hash.

Fixes https://github.com/rantly-rb/rantly/issues/39