### PR TITLE
Only support Ruby 2.4 and 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ cache: bundler
 after_success:
   - coveralls
 rvm:
-    - 2.0.0
-    - 2.1.9
-    - 2.2.6
-    - 2.3.3
     - 2.4.0
     - jruby-1.7.26
     - jruby-9.1.7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: bundler
 after_success:
   - coveralls
 rvm:
+    - 2.5.1
     - 2.4.0
     - jruby-1.7.26
     - jruby-9.1.7.0

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Its implementation has no alien mathematics inside. Completely side-effect-free-
 
 # Install
 
+Rantly requires Ruby 2.4 or higher. To install Ruby:
+
 ```ruby
 $ gem install rantly
 ```

--- a/rantly.gemspec
+++ b/rantly.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
     "test/shrinks_test.rb",
     "test/test_helper.rb"
   ]
+  s.required_ruby_version = '>= 2.4.0'
 
   s.add_development_dependency('rake',      '~> 12.0.0')
   s.add_development_dependency('minitest',  '~> 5.10.0')


### PR DESCRIPTION
I think before merging this, a new version of Rantly including https://github.com/rantly-rb/rantly/pull/40 should be released :wink: 

Closes #37