### PR TITLE
Only support JRuby 9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ cache: bundler
 after_success:
   - coveralls
 rvm:
-    - 2.5.1
     - 2.4.0
+    - 2.5.1
     - ruby-head
     - jruby-9.2.0.0
     - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ rvm:
     - 2.5.1
     - 2.4.0
     - ruby-head
-    - jruby-1.7.26
-    - jruby-9.1.7.0
     - jruby-head
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
     - 2.5.1
     - 2.4.0
     - ruby-head
+    - jruby-9.2.0.0
     - jruby-head
 
 matrix:


### PR DESCRIPTION
As in https://github.com/rantly-rb/rantly/pull/44, I think before merging this, a new version of Rantly including https://github.com/rantly-rb/rantly/pull/40 should be released :wink: 

Closes https://github.com/rantly-rb/rantly/issues/42