### PR TITLE
Correct license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,5 +404,5 @@ Thanks to [all contributors](https://github.com/rantly-rb/rantly/graphs/contribu
 
 # License
 
-Code published under MIT License, Copyright (c) 2009 Howard Yeh. See [LICENSE](https://github.com/abargnesi/rantly/LICENSE).
+Code published under MIT License, Copyright (c) 2009 Howard Yeh. See [LICENSE](/LICENSE).
 


### PR DESCRIPTION
The url was wrong and pointing to the old repository url. :bowtie: 