### PR TITLE
Fix circular buffer example

### DIFF
--- a/examples/01-circular_buffer/.gitignore
+++ b/examples/01-circular_buffer/.gitignore
@@ -1,0 +1,2 @@
+circular_buffer
+circular_buffer.txt

--- a/examples/01-circular_buffer/README
+++ b/examples/01-circular_buffer/README
@@ -2,7 +2,7 @@ HOW TO RUN
 
   $ cd examples-01-circular-buffer
   $ gcc -o circular_buffer circular_buffer_bugged.c
-  $ rspec tests/tests.rb
+  $ rspec spec/tests.rb
 
 
 WHAT IT DOES

--- a/examples/01-circular_buffer/circular_buffer.c
+++ b/examples/01-circular_buffer/circular_buffer.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
 
 #define FILE_NAME "circular_buffer.txt"
 #define RECORD_SIZE 9L

--- a/examples/01-circular_buffer/circular_buffer_bugged.c
+++ b/examples/01-circular_buffer/circular_buffer_bugged.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
 
 #define FILE_NAME "circular_buffer.txt"
 #define RECORD_SIZE 9L

--- a/examples/01-circular_buffer/spec/tests.rb
+++ b/examples/01-circular_buffer/spec/tests.rb
@@ -1,6 +1,7 @@
 require 'rantly'
 require 'rantly/rspec_extensions'
 require 'rantly/shrinks'
+require 'English'
 
 PROGRAM = './circular_buffer'.freeze
 FILE = 'circular_buffer.txt'.freeze


### PR DESCRIPTION
- Include <string.h> in the two C implementations for strcmp.
- Require the `English` module in the test, so that the $CHILD_STATUS
  alias for $? is loaded.

I ran into these issues while trying to run the example.

I'm not sure how the C programs ever compiled without the header, but clang and gcc both complain for me.

I think the `English` module was added in Ruby 2.0, so requiring it might not have been necessary before then.