### PR TITLE
Support the latest rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 inherit_from: .rubocop_todo.yml
 
 AllCops:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,7 +22,12 @@ Lint/AmbiguousBlockAssociation:
     - 'test/rantly_test.rb'
 
 # Offense count: 1
-Lint/HandleExceptions:
+Lint/MissingSuper:
+  Exclude:
+    - 'lib/rantly/generator.rb'
+
+# Offense count: 1
+Lint/SuppressedException:
   Exclude:
     - 'test/test_helper.rb'
 
@@ -44,10 +49,20 @@ Metrics/BlockNesting:
     - 'lib/rantly/property.rb'
 
 # Offense count: 1
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'lib/rantly/generator.rb'
+
+# Offense count: 1
 # Configuration parameters: CountComments, Max, ExcludedMethods.
 Metrics/MethodLength:
   Exclude:
     - 'lib/rantly/property.rb'
+
+# Offense count: 1
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'lib/rantly/generator.rb'
 
 # Offense count: 1
 # Configuration parameters: Blacklist.
@@ -67,7 +82,7 @@ Naming/MethodName:
 # Offense count: 22
 # Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
 # AllowedNames: io, id, to, by, on, in, at, ip, db
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Exclude:
     - 'lib/rantly.rb'
     - 'lib/rantly/generator.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ group :development, :test do
   gem 'simplecov', '>= 0'
 
   gem 'rubocop'
+  gem 'rubocop-performance', require: false
 end

--- a/lib/rantly/generator.rb
+++ b/lib/rantly/generator.rb
@@ -1,6 +1,7 @@
 class Rantly
   class << self
     attr_writer :default_size
+
     def singleton
       @singleton ||= Rantly.new
       @singleton

--- a/lib/rantly/property.rb
+++ b/lib/rantly/property.rb
@@ -5,12 +5,12 @@ require 'stringio'
 class Rantly::Property
   attr_reader :failed_data, :shrunk_failed_data
 
-  VERBOSITY = ENV.fetch('RANTLY_VERBOSE') { 1 }.to_i
-  RANTLY_COUNT = ENV.fetch('RANTLY_COUNT') { 100 }.to_i
+  VERBOSITY = ENV.fetch('RANTLY_VERBOSE', 1).to_i
+  RANTLY_COUNT = ENV.fetch('RANTLY_COUNT', 100).to_i
 
   def io
     @io ||= if VERBOSITY >= 1
-              STDOUT
+              $stdout
             else
               StringIO.new
             end
@@ -41,7 +41,7 @@ class Rantly::Property
       io.puts
       io.puts "FAILURE - #{i} successful tests, too many tries: #{e.tries}"
       raise e.exception("#{i} successful tests, too many tries: #{e.tries} (limit: #{e.limit})")
-    rescue Exception => boom
+    rescue Exception => e
       io.puts
       io.puts "FAILURE - #{i} successful tests, failed on:"
       pretty_print test_data
@@ -51,7 +51,7 @@ class Rantly::Property
         io.puts "Minimal failed data (depth #{@depth}) is:"
         pretty_print @shrunk_failed_data
       end
-      raise boom.exception("#{i} successful tests, failed on:\n#{test_data}\n\n#{boom}\n")
+      raise e.exception("#{i} successful tests, failed on:\n#{test_data}\n\n#{e}\n")
     end
   end
 

--- a/lib/rantly/shrinks.rb
+++ b/lib/rantly/shrinks.rb
@@ -1,18 +1,17 @@
 # Integer : shrink to zero
 class Integer
   def shrink
-    shrunk = if self > 8
-               self / 2
-             elsif self > 0
-               self - 1
-             elsif self < -8
-               (self + 1) / 2
-             elsif self < 0
-               self + 1
-             else
-               0
+    if self > 8
+      self / 2
+    elsif self > 0
+      self - 1
+    elsif self < -8
+      (self + 1) / 2
+    elsif self < 0
+      self + 1
+    else
+      0
     end
-    shrunk
   end
 
   def retry?


### PR DESCRIPTION
I got the following error when I ran `bundle exec rake` with the latest version of rubocop, so I fixed it in this PR.

```
warning: parser/current is loading parser/ruby26, which recognizes                                                                                                               
warning: 2.6.6-compliant syntax, but you are running 2.6.0.                             
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.                                                                                            
Running RuboCop...                                                                                                                                                               
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout                                                                                                      
Error: The `Lint/HandleExceptions` cop has been renamed to `Lint/SuppressedException`.  
(obsolete configuration found in .rubocop_todo.yml, please update it)                                                                                                            
The `Naming/UncommunicativeMethodParamName` cop has been renamed to `Naming/MethodParameterName`.                                                                                
(obsolete configuration found in .rubocop_todo.yml, please update it)                                                                                                            
`Performance/*` has been extracted to the `rubocop-performance` gem.                                                                                                             
(obsolete configuration found in .rubocop_todo.yml, please update it)                                                                                                            
RuboCop failed!  
```

```
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.6-compliant syntax, but you are running 2.6.0.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Running RuboCop...
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.

Please also note that can also opt-in to new cops by default by adding this to your config:
  AllCops:
    NewCops: enable

Layout/SpaceBeforeBrackets: # (new in 1.7)
  Enabled: true
Lint/AmbiguousAssignment: # (new in 1.7)
  Enabled: true
Lint/DeprecatedConstants: # (new in 1.8)
  Enabled: true
Lint/DuplicateBranch: # (new in 1.3)
  Enabled: true
Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
  Enabled: true
Lint/EmptyBlock: # (new in 1.1)
  Enabled: true
Lint/EmptyClass: # (new in 1.3)
  Enabled: true
Lint/LambdaWithoutLiteralBlock: # (new in 1.8)
  Enabled: true
Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
  Enabled: true
Lint/RedundantDirGlobSort: # (new in 1.8)
  Enabled: true
Lint/ToEnumArguments: # (new in 1.1)
  Enabled: true
Lint/UnexpectedBlockArity: # (new in 1.5)
  Enabled: true
Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
  Enabled: true
Style/ArgumentsForwarding: # (new in 1.1)
  Enabled: true
Style/CollectionCompact: # (new in 1.2)
  Enabled: true
Style/DocumentDynamicEvalDefinition: # (new in 1.1)
  Enabled: true
Style/EndlessMethod: # (new in 1.8)
  Enabled: true
Style/HashExcept: # (new in 1.7)
  Enabled: true
Style/NegatedIfElseCondition: # (new in 1.2)
  Enabled: true
Style/NilLambda: # (new in 1.3)
  Enabled: true
Style/RedundantArgument: # (new in 1.4)
  Enabled: true
Style/SwapValues: # (new in 1.1)
  Enabled: true
Performance/AncestorsInclude: # (new in 1.7)
  Enabled: true
Performance/BigDecimalWithNumericArgument: # (new in 1.7)
  Enabled: true
Performance/BlockGivenWithExplicitBlock: # (new in 1.9)
  Enabled: true
Performance/CollectionLiteralInLoop: # (new in 1.8)
  Enabled: true
Performance/ConstantRegexp: # (new in 1.9)
  Enabled: true
Performance/MethodObjectAsBlock: # (new in 1.9)
  Enabled: true
Performance/RedundantSortBlock: # (new in 1.7)
  Enabled: true
Performance/RedundantStringChars: # (new in 1.7)
  Enabled: true
Performance/ReverseFirst: # (new in 1.7)
  Enabled: true
Performance/SortReverse: # (new in 1.7)
  Enabled: true
Performance/Squeeze: # (new in 1.7)
  Enabled: true
Performance/StringInclude: # (new in 1.7)
  Enabled: true
Performance/Sum: # (new in 1.8)
  Enabled: true
For more information: https://docs.rubocop.org/rubocop/versioning.html
Inspecting 21 files
......W..C..C........

Offenses:

lib/rantly/generator.rb:3:5: C: [Correctable] Layout/EmptyLinesAroundAttributeAccessor: Add an empty line after attribute accessor.
    attr_writer :default_size
    ^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rantly/generator.rb:34:5: W: Lint/MissingSuper: Call super to initialize state of the parent class.
    def initialize(limit, nfailed) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rantly/generator.rb:194:3: C: Metrics/CyclomaticComplexity: Cyclomatic complexity for freq is too high. [9/7]
  def freq(*pairs) ...
  ^^^^^^^^^^^^^^^^
lib/rantly/generator.rb:194:3: C: Metrics/PerceivedComplexity: Perceived complexity for freq is too high. [9/8]
  def freq(*pairs) ...
  ^^^^^^^^^^^^^^^^
lib/rantly/property.rb:8:19: C: [Correctable] Style/RedundantFetchBlock: Use fetch('RANTLY_VERBOSE', 1) instead of fetch('RANTLY_VERBOSE') { 1 }.
  VERBOSITY = ENV.fetch('RANTLY_VERBOSE') { 1 }.to_i
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rantly/property.rb:9:22: C: [Correctable] Style/RedundantFetchBlock: Use fetch('RANTLY_COUNT', 100) instead of fetch('RANTLY_COUNT') { 100 }.
  RANTLY_COUNT = ENV.fetch('RANTLY_COUNT') { 100 }.to_i
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rantly/property.rb:13:15: C: [Correctable] Style/GlobalStdStream: Use $stdout instead of STDOUT.
              STDOUT
              ^^^^^^
lib/rantly/property.rb:44:25: C: [Correctable] Naming/RescuedExceptionsVariableName: Use e instead of boom.
    rescue Exception => boom
                        ^^^^
lib/rantly/shrinks.rb:4:5: C: [Correctable] Style/RedundantAssignment: Redundant assignment before returning detected.
    shrunk = if self > 8 ...
    ^^^^^^^^^^^^^^^^^^^^

21 files inspected, 9 offenses detected, 6 offenses auto-correctable

Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-minitest (http://github.com/rubocop-hq/rubocop-minitest)
  * rubocop-rake (http://github.com/rubocop-hq/rubocop-rake)

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
RuboCop failed!
```