### PR TITLE
Feature: added extension for rspec-rails. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,10 @@ Rantly::TooManyTries: Exceed gen limit 60: 60 failed guards)
 Rantly extends Test::Unit and MiniTest::Test (5.0)/MiniTest::Unit::TestCase (< 5.0) for property testing. The extensions are in their own modules. So you need to require them explicitly:
 
 ```ruby
-require 'rantly/testunit_extensions' # for 'test/unit'
-require 'rantly/minitest_extensions' # for 'minitest'
-require 'rantly/rspec_extensions'    # for RSpec
+require 'rantly/testunit_extensions'    # for 'test/unit'
+require 'rantly/minitest_extensions'    # for 'minitest'
+require 'rantly/rspec_extensions'       # for RSpec
+require 'rantly/rspec_rails_extensions' # for rspec-rails
 ```
 
 They define:

--- a/lib/rantly/rspec_rails.rb
+++ b/lib/rantly/rspec_rails.rb
@@ -1,0 +1,1 @@
+require 'rantly/rspec_rails_extensions'

--- a/lib/rantly/rspec_rails_extension.rb
+++ b/lib/rantly/rspec_rails_extension.rb
@@ -1,0 +1,8 @@
+require 'rspec-rails'
+require 'rantly/property'
+
+class RSpec::Core::ExampleGroup
+  def property_of(&block)
+    Rantly::Property.new(block)
+  end
+end


### PR DESCRIPTION
`rspec-rails` uses the same core rspec libraries, but it seems that it is its own project. 

To avoid adding an extra dependency (rspec) on a project that already uses rspec-rails
rantly can provide an extension specific for it.

Closes #78 