### PR TITLE
[Fixed] change rspec dependency to rspec core

### DIFF
--- a/lib/rantly/rspec_extensions.rb
+++ b/lib/rantly/rspec_extensions.rb
@@ -1,4 +1,4 @@
-require 'rspec'
+require 'rspec/core'
 require 'rantly/property'
 
 class RSpec::Core::ExampleGroup


### PR DESCRIPTION
Closes #78 

@dennyabraham found that rantly only depends on `rspec/core`, not the whole `rspec`. 

This will fix the problem with the rspec-rails version, which is a different project, 
but both uses the same core libraries.