### PR TITLE
Conditionally load MiniTest compatibility layer

### DIFF
--- a/lib/rantly/minitest_extensions.rb
+++ b/lib/rantly/minitest_extensions.rb
@@ -1,5 +1,6 @@
 require 'minitest'
 require 'rantly/property'
+require "minitest/unit" unless defined?(MiniTest)
 
 test_class = if defined?(MiniTest::Test)
                MiniTest::Test


### PR DESCRIPTION
Rantly doesn't work with Minitest > 5.18.1 because they [moved a compatibility check](https://my.diffend.io/gems/minitest/5.18.1/5.19.0) to an environment variable. Adding this conditional require resolves the issue.